### PR TITLE
Align uncompressed serialization w/zkcrypto spec

### DIFF
--- a/g1.go
+++ b/g1.go
@@ -144,6 +144,27 @@ func (g G1Affine) Equals(other *G1Affine) bool {
 	return (g.infinity == other.infinity) || (g.x.Equals(other.x) && g.y.Equals(other.y))
 }
 
+// SerializeBytes returns the serialized bytes for the point represented.
+func (g *G1Affine) SerializeBytes() []byte {
+	out := [96]byte{}
+
+	copy(out[0:48], g.x.n.Bytes())
+	copy(out[48:96], g.y.n.Bytes())
+
+	return out[:]
+}
+
+// SetRawBytes sets the coords given the serialized bytes.
+func (g *G1Affine) SetRawBytes(uncompressed []byte) {
+	g.x = &FQ{
+		n: new(big.Int).SetBytes(uncompressed[0:48]),
+	}
+	g.y = &FQ{
+		n: new(big.Int).SetBytes(uncompressed[48:96]),
+	}
+	return
+}
+
 // DecompressG1 decompresses the big int into an affine point and checks
 // if it is in the correct prime group.
 func DecompressG1(b *big.Int) (*G1Affine, error) {

--- a/g2.go
+++ b/g2.go
@@ -146,6 +146,31 @@ func GetG2PointFromX(x *FQ2, greatest bool) *G2Affine {
 	return NewG2Affine(x, yVal)
 }
 
+// SerializeBytes returns the serialized bytes for the points represented.
+func (g *G2Affine) SerializeBytes() []byte {
+	out := [192]byte{}
+
+	copy(out[0:48], g.x.c0.n.Bytes())
+	copy(out[48:96], g.x.c1.n.Bytes())
+	copy(out[96:144], g.y.c0.n.Bytes())
+	copy(out[144:192], g.y.c1.n.Bytes())
+
+	return out[:]
+}
+
+// SetRawBytes sets the coords given the serialized bytes.
+func (g *G2Affine) SetRawBytes(uncompressed []byte) {
+	g.x = &FQ2{
+		c0: &FQ{n: new(big.Int).SetBytes(uncompressed[0:48])},
+		c1: &FQ{n: new(big.Int).SetBytes(uncompressed[48:96])},
+	}
+	g.y = &FQ2{
+		c0: &FQ{n: new(big.Int).SetBytes(uncompressed[96:144])},
+		c1: &FQ{n: new(big.Int).SetBytes(uncompressed[144:192])},
+	}
+	return
+}
+
 // DecompressG2 decompresses a G2 point from a big int and checks
 // if it is in the correct subgroup.
 func DecompressG2(b *big.Int) (*G2Affine, error) {


### PR DESCRIPTION
Hi! I've been following this code base for a couple weeks now, and love the work. (Esp. the bugfix for pubkeys w/0 at the beginning, which was driving me crazy for the last week.)

It looks like you are implementing the spec here:

https://github.com/zkcrypto/pairing/tree/master/src/bls12_381

If this is the case, it looks like the serialization for the latest commit (uncompressed pubkeys) doesn't match exactly. This PR is an attempt to help it line up w/that spec.

Since all coords use a max of 381 bits, there should be 3 bits at the beginning of the serialization even for uncompressed pubkeys/sigs `((48 * 8) - 381)`, so the extra byte shouldn't be necessary.

The interface I've added to G1Affine and G2Affine allows quick serialization and deserialization of bytes which represent the coords, but also allows to easily swap G1 and G2 for implementations such as https://github.com/Chia-Network/bls-signatures/blob/master/SPEC.md (which I am working on).

Also, I believe in the near future it should be fairly easy to combine DeserializePubKey for both compressed and uncompressed based on the size of the byte slice. I will probably work on that in a few hours, and hopefully this PR is acceptable for this repo.
