### PR TITLE
add CompareTwoPairings

### DIFF
--- a/g1.go
+++ b/g1.go
@@ -255,6 +255,11 @@ type G1Projective struct {
 	z FQ
 }
 
+// NegAssign negates the point.
+func (g *G1Projective) NegAssign() {
+	g.y.NegAssign()
+}
+
 // NewG1Projective creates a new G1Projective point.
 func NewG1Projective(x FQ, y FQ, z FQ) *G1Projective {
 	return &G1Projective{x, y, z}

--- a/g1pubs/bls.go
+++ b/g1pubs/bls.go
@@ -154,17 +154,13 @@ func KeyFromFQRepr(i *bls.FRRepr) *SecretKey {
 // Verify verifies a signature against a message and a public key.
 func Verify(m []byte, pub *PublicKey, sig *Signature) bool {
 	h := bls.HashG2(m)
-	lhs := bls.Pairing(bls.G1ProjectiveOne, sig.s)
-	rhs := bls.Pairing(pub.p, h.ToProjective())
-	return lhs.Equals(rhs)
+	return bls.CompareTwoPairings(bls.G1ProjectiveOne, sig.s, pub.p, h.ToProjective())
 }
 
 // VerifyWithDomain verifies a signature against a message and a public key and a domain
 func VerifyWithDomain(m [32]byte, pub *PublicKey, sig *Signature, domain [8]byte) bool {
 	h := bls.HashG2WithDomain(m, domain)
-	lhs := bls.Pairing(bls.G1ProjectiveOne, sig.s)
-	rhs := bls.Pairing(pub.p, h.ToAffine().ToProjective())
-	return lhs.Equals(rhs)
+	return bls.CompareTwoPairings(bls.G1ProjectiveOne, sig.s, pub.p, h.ToAffine().ToProjective())
 }
 
 // AggregateSignatures adds up all of the signatures.

--- a/g2pubs/bls.go
+++ b/g2pubs/bls.go
@@ -148,9 +148,7 @@ func KeyFromFQRepr(i *bls.FRRepr) *SecretKey {
 // Verify verifies a signature against a message and a public key.
 func Verify(m []byte, pub *PublicKey, sig *Signature) bool {
 	h := bls.HashG1(m)
-	lhs := bls.Pairing(sig.s, bls.G2ProjectiveOne)
-	rhs := bls.Pairing(h.ToProjective(), pub.p)
-	return lhs.Equals(rhs)
+	return bls.CompareTwoPairings(sig.s, bls.G2ProjectiveOne, h.ToProjective(), pub.p)
 }
 
 // AggregateSignatures adds up all of the signatures.

--- a/pairing.go
+++ b/pairing.go
@@ -134,3 +134,14 @@ func Pairing(p *G1Projective, q *G2Projective) *FQ12 {
 		{p.ToAffine(), G2AffineToPrepared(q.ToAffine())},
 	}))
 }
+
+// CompareTwoPairings checks e(P1, Q1) == e(P2, Q2)
+// <=> FE(ML(P1, Q1)ML(-P2, Q2)) == 1
+func CompareTwoPairings(P1 *G1Projective, Q1 *G2Projective, P2 *G1Projective, Q2 *G2Projective) bool {
+	negP2 := P2.Copy()
+	negP2.NegAssign()
+	return FinalExponentiation(
+		MillerLoop(
+			[]MillerLoopItem{{P1.ToAffine(), G2AffineToPrepared(Q1.ToAffine())}, {negP2.ToAffine(), G2AffineToPrepared(Q2.ToAffine())}})).Equals(FQ12One)
+
+}


### PR DESCRIPTION
The `Verify` function computes e(P1, Q1) == e(P2, Q2) where e is pairing.
But Pairing(P, Q) = FE(ML(P, Q)) where ML is MillerLoop and FE is FinalExponentiation.
e(P1, Q1) == e(P2, Q2)
<=> e(P1, Q1) e(-P2, Q2) == 1
<=> FE(ML(P1, Q1) ML(P2, Q2)) == 1 then I added `CompareTwoPairings`, which can reduce one FE.
I got the following speed on Core i7-7700 3.6GHz:

* original g1pubs
```
bls/g1pubs% go test --bench .
goos: linux
goarch: amd64
pkg: github.com/phoreproject/bls/g1pubs
BenchmarkBLSAggregateSignature-4                  200000              8234 ns/op
BenchmarkBLSSign-4                                   500           3755491 ns/op
BenchmarkBLSVerify-4                                 100          14766535 ns/op
BenchmarkVerifyWithDomain-4                          100          16862432 ns/op
BenchmarkVerifyAggregateCommonWithDomain-4           100          16845176 ns/op
BenchmarkVerifyAggregateMultipleWithDomain-4           1        1327194394 ns/op
```

* optimized g1pubs
```
pkg: github.com/phoreproject/bls/g1pubs
BenchmarkBLSAggregateSignature-4                  200000              8189 ns/op
BenchmarkBLSSign-4                                   500           3809514 ns/op
BenchmarkBLSVerify-4                                 100          10010070 ns/op
BenchmarkVerifyWithDomain-4                          100          11823728 ns/op
BenchmarkVerifyAggregateCommonWithDomain-4           100          11900917 ns/op
BenchmarkVerifyAggregateMultipleWithDomain-4           1        1349163898 ns/op
```

* original g2pubs
```
bls/g2pubs% go test --bench .
BenchmarkBLSAggregateSignature-4         1000000              2143 ns/op
BenchmarkBLSSign-4                          2000           1073271 ns/op
BenchmarkBLSVerify-4                         100          13116371 ns/op
```

* optimized g2pubs
```
goos: linux
goarch: amd64
pkg: github.com/phoreproject/bls/g2pubs
BenchmarkBLSAggregateSignature-4         1000000              2144 ns/op
BenchmarkBLSSign-4                          2000           1081131 ns/op
BenchmarkBLSVerify-4                         200           8058618 ns/op
```